### PR TITLE
manager: add height and mine to height, add transition network node

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,10 +5,21 @@ import (
 	"go.sia.tech/core/types"
 )
 
+// HeightResponse is the response type for [GET] /height.
+type HeightResponse struct {
+	Height uint64 `json:"height"`
+}
+
 // MineRequest is the request type for [POST] /mine.
 type MineRequest struct {
 	Blocks  int           `json:"blocks"`
 	Address types.Address `json:"address"`
+}
+
+// MineToRequest is the request type for [POST] /mine/to.
+type MineToRequest struct {
+	TargetHeight uint64        `json:"targetHeight"`
+	Address      types.Address `json:"address"`
 }
 
 // A ProxyResponse is the response for a proxied API request from a node.

--- a/cmd/clusterd/main.go
+++ b/cmd/clusterd/main.go
@@ -123,6 +123,9 @@ func main() {
 	case "v2":
 		n.HardforkV2.AllowHeight = 2
 		n.HardforkV2.RequireHeight = 3
+	case "transition":
+		n.HardforkV2.AllowHeight = 200 // attainable and after 144
+		n.HardforkV2.RequireHeight = 300
 	default:
 		log.Fatal("invalid network", zap.String("network", network))
 	}

--- a/nodes/manager.go
+++ b/nodes/manager.go
@@ -213,6 +213,27 @@ func (m *Manager) MineBlocks(ctx context.Context, n int, rewardAddress types.Add
 	return nil
 }
 
+// MineBlocksToHeight mines blocks until the target height is reached.
+func (m *Manager) MineBlocksToHeight(ctx context.Context, targetHeight uint64, rewardAddress types.Address) error {
+	log := m.log.Named("mineToHeight")
+	currentHeight := m.chain.Tip().Height
+
+	log.Debug("mining to height",
+		zap.Uint64("currentHeight", currentHeight),
+		zap.Uint64("targetHeight", targetHeight))
+
+	for currentHeight < targetHeight {
+		if err := m.MineBlocks(ctx, 1, rewardAddress); err != nil {
+			return fmt.Errorf("failed to mine to height %v: %w", targetHeight, err)
+		}
+		currentHeight = m.chain.Tip().Height
+	}
+
+	log.Debug("finished mining to height",
+		zap.Uint64("height", currentHeight))
+	return nil
+}
+
 func createNodeDir(baseDir string, id NodeID) (dir string, err error) {
 	dir = filepath.Join(baseDir, id.String())
 	if err := os.MkdirAll(dir, 0700); err != nil {


### PR DESCRIPTION
- Add manager endpoints:
  - `[GET] /height` Convenient way to get the current network height.
  - `[POST] /mine/to { targetHeight: number }` Allows us to mine to a specific height.
- Add `-network=transition` mode that sets the activation height just pass the 144 that is automatically mined so that we can test v1 vs v2 transaction behaviours depending on the exact current height.