### PR TITLE
chore: update network transition mode heights

### DIFF
--- a/cmd/clusterd/main.go
+++ b/cmd/clusterd/main.go
@@ -124,8 +124,8 @@ func main() {
 		n.HardforkV2.AllowHeight = 2
 		n.HardforkV2.RequireHeight = 3
 	case "transition":
-		n.HardforkV2.AllowHeight = 200 // attainable and after 144
-		n.HardforkV2.RequireHeight = 300
+		n.HardforkV2.AllowHeight = 300
+		n.HardforkV2.RequireHeight = 400
 	default:
 		log.Fatal("invalid network", zap.String("network", network))
 	}


### PR DESCRIPTION
- 200/300 was too low, the cluster init takes it past 200.
- `web/internal/cluster` sets these and reimplements the whole file anyway but wanted to keep these in sync, alternatively we could delete this network mode here.