### PR TITLE
Support publishing indexd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go-version: ['1.24', '1.25']
+        go-version: ["1.25", "1.26"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-**"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -24,3 +21,33 @@ jobs:
       macos-build-args: -tags=timetzdata -trimpath -a -ldflags '-s -w'
       cgo-enabled: 1
       project: clusterd
+
+  docker:
+    name: Publish Docker
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.26
+      - name: Setup Indexd Access
+        run: |
+          echo "${{ secrets.INDEXD_SSH_KEY }}" > $GITHUB_WORKSPACE/indexd_ed25519
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/siafoundation/cluster:master
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM docker.io/library/golang:1.26 AS builder
 
 WORKDIR /app
 
+# install git-lfs for indexd dependency (contains LFS-tracked files)
+RUN apt-get update && apt-get install -y git-lfs && rm -rf /var/lib/apt/lists/*
+
 # setup auth for indexd package access
 RUN mkdir -p ~/.ssh \
     && chmod 700 ~/.ssh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,19 @@ FROM docker.io/library/golang:1.26 AS builder
 
 WORKDIR /app
 
+# setup auth for indexd package access
+RUN mkdir -p ~/.ssh \
+    && chmod 700 ~/.ssh \
+    && ssh-keyscan github.com >> ~/.ssh/known_hosts \
+    && chmod 644 ~/.ssh/known_hosts
+
+COPY indexd_ed25519 /root/.ssh/id_ed25519
+RUN chmod 600 ~/.ssh/id_ed25519
+RUN git config --global url."git@github.com:".insteadOf "https://github.com/"
+RUN git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"
+
+ENV GOPRIVATE=go.sia.tech/indexd
+
 # get dependencies
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
This updates the publish CI action to use an ssh key to be able to access the indexd repo at the cost of no longer building the binaries. If we feel like that's an ok tradeoff we can merge this.